### PR TITLE
Upcoming events

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -83,6 +83,8 @@ programme:
         url: /programme/calendar/
       - title: "Ask us anything"
         url: "/programme/ask-us-anything/"
+  - &teams
+    children:
       # - title: Awards
       #   url: "/programme/awards/"
       - title: Panels and Discussions
@@ -103,6 +105,7 @@ programme:
 programme_faq:
   - *sorse20
   - *programme
+  - *teams
   - *faq
 
 coc:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -13,6 +13,8 @@ news:
     title: SORSE
     url: /
     children:
+      - title: Upcoming events
+        url: /programme/
       - title: Aims of SORSE
         url: "/faq/about/what-is-sorse"
       - title: "Format of SORSE"

--- a/_includes/event.js
+++ b/_includes/event.js
@@ -1,0 +1,8 @@
+{
+  title  : '{{ post.title }}',
+  url    : "{{ post.url | relative_url }}",
+  allDay : {% if post.all_day %}true{% else %}false{% endif %},
+  category : "{{ post.category }}",
+  {% unless post.end_date %}// {% endunless %}end    : '{{ event.end_date | date_to_xmlschema }},'
+  start  : '{{ post.date | date_to_xmlschema }}'
+}

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -1,4 +1,6 @@
 <div id='calendar'></div>
+[Full event calendar]({{ "/programme/calendar/" | relative_url }})
+{: .text-right}
 
 <script>
 

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -1,0 +1,28 @@
+<div id='calendar'></div>
+
+<script>
+
+ document.addEventListener('DOMContentLoaded', function() {
+   var calendarEl = document.getElementById('calendar');
+
+   var events = [
+      {% for post in site.events %}
+      {% include event.js %}{% if forloop.last %}{% else %},{% endif %}
+      {% endfor %}
+   ];
+
+   events = events.filter(e => new Date(e.start) >= new Date());
+   events.sort((e1, e2) => new Date(e1.start) - new Date(e2.start));
+
+   calendar = new FullCalendar.Calendar(calendarEl, {
+     headerToolbar: false,
+     noEventsContent: "No upcoming events",
+     timeZone: 'UTC',
+     initialView: 'listYear',
+     editable: true,
+     selectable: true,
+     events: events
+   });
+  calendar.render();
+});
+</script>

--- a/_layouts/calendar.html
+++ b/_layouts/calendar.html
@@ -1,0 +1,36 @@
+---
+layout: single
+---
+
+{{ content }}
+
+<div id='calendar'></div>
+
+<script>
+
+ document.addEventListener('DOMContentLoaded', function() {
+   var calendarEl = document.getElementById('calendar');
+
+   calendar = new FullCalendar.Calendar(calendarEl, {
+     headerToolbar: {
+       left: 'prev,next today',
+       center: 'title',
+       right: 'dayGridMonth,listWeek,listDay'
+     },
+     buttonText: {
+       week: 'week',
+       day: 'day'
+     },
+     timeZone: 'UTC',
+     initialView: 'dayGridMonth',
+     editable: true,
+     selectable: true,
+     events: [
+        {% for post in site.events %}
+        {% include event.js %}{% if forloop.last %}{% else %},{% endif %}
+        {% endfor %}
+     ]
+   });
+  calendar.render();
+});
+</script>

--- a/_layouts/collection-categories.html
+++ b/_layouts/collection-categories.html
@@ -2,8 +2,6 @@
 layout: archive
 ---
 
-{{ content }}
-
 {% assign collection = site[page.collection] %}
 {% include group-by-array collection=collection field="category" %}
 
@@ -17,6 +15,9 @@ layout: archive
     </li>
   {% endfor %}
 </ul>
+
+
+{{ content }}
 
 
 {% for category in group_names %}

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -13,6 +13,7 @@ header:
     - label: Submit an abstract
       url: /programme/call-for-contributions/
 excerpt: International Series of Online Research Software Events
+fullcalendar: true
 ---
 
 <aside id="twitter-holder" class="sidebar__right sticky">
@@ -25,7 +26,7 @@ This is an open call to all RSEs and anyone involved with research software worl
 
 Any questions, read [more](faq/about/what-is-sorse) or [get in touch](contact/)!
 
-### News
+## News
 
 {% if paginator %}
   {% assign posts = paginator.categories["news"] %}
@@ -39,4 +40,6 @@ Any questions, read [more](faq/about/what-is-sorse) or [get in touch](contact/)!
 
 {% include paginator.html %}
 
-### Upcoming Events
+## Upcoming Events
+
+{% include upcoming-events.html %}

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -24,7 +24,7 @@ Welcome to SORSE - A **S**eries of **O**nline **R**esearch **S**oftware **E**ven
 
 This is an open call to all RSEs and anyone involved with research software worldwide, to propose a talk, a workshop, a software demo, a panel or discussion, blog post or poster. After the each event, SORSE will provide an opportunity for networking and informal discussion with other participants in small groups.
 
-Any questions, read [more](faq/about/what-is-sorse) or [get in touch](contact/)!
+Any questions, read [more](faq/about/what-is-sorse), [get in touch](contact/), or see [upcoming events](#upcoming-events)!
 
 ## News
 

--- a/_pages/programme/calendar.md
+++ b/_pages/programme/calendar.md
@@ -7,38 +7,5 @@ classes: wide
 toc: true
 toc_sticky: true
 fullcalendar: true
+layout: calendar
 ---
-
-<div id='calendar'></div>
-
-<script>
-
- document.addEventListener('DOMContentLoaded', function() {
-   var calendarEl = document.getElementById('calendar');
-
-   var calendar = new FullCalendar.Calendar(calendarEl, {
-     headerToolbar: {
-       left: 'prev,next today',
-       center: 'title',
-       right: 'dayGridMonth,listWeek,listDay'
-     },
-     buttonText: {
-       week: 'week',
-       day: 'day'
-     },
-     timeZone: 'UTC',
-     initialView: 'dayGridMonth',
-     editable: true,
-     selectable: true,
-     events: [{% for event in site.events %}{
-       title  : '{{ event.title }}',
-       url    : "{{ event.url | relative_url }}",
-       allDay : {% if event.all_day %}true{% else %}false{% endif %},
-       {% unless event.end_date %}// {% endunless %}end    : '{{ event.end_date | date_to_xmlschema }}'
-       start  : '{{ event.date | date_to_xmlschema }}'
-      }{% if forloop.last %}{% else %},{% endif %}{% endfor %}
-     ]
-   });
-  calendar.render();
-});
-</script>

--- a/_pages/programme/index.md
+++ b/_pages/programme/index.md
@@ -5,7 +5,9 @@ collection: events
 permalink: /programme/
 sidebar:
   nav:  programme
+fullcalendar: true
 ---
 
-HERE SHOULD BE A SCHEDULE
-{: notice--alert}
+## Upcoming events
+
+{% include upcoming-events.html %}

--- a/_sass/fc.scss
+++ b/_sass/fc.scss
@@ -1,6 +1,6 @@
 
 // override table properties of minimal-mistakes
-.fc-daygrid table {
+.fc-daygrid table, .fc-list-table {
   display: table;
   margin-bottom: 0;
 }


### PR DESCRIPTION
This PR adds upcoming events to the front and programme page with the strategy discussed in https://github.com/Chilipp/sorse.github.io/pull/1#issuecomment-653220837. For this purpose, I also outsourced parts of the calendar setup into a calendar layout and upcoming-events.html include.

See 

- the front page: https://11-276193679-gh.circle-artifacts.com/0/SORSE/index.html#upcoming-events
- the programme page: https://11-276193679-gh.circle-artifacts.com/0/SORSE/programme/index.html

What do you think about this approach @vsoch? I'll go asleep now.