### PR TITLE
Add author and time info to events

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -136,7 +136,7 @@ defaults:
       collection_button:
         name: Schedule
         url: /programme/
-      layout: single
+      layout: event
 
 collections:
   bazaar:

--- a/_events/software_demos/event-001.md
+++ b/_events/software_demos/event-001.md
@@ -6,7 +6,10 @@ authors:
     email: nomail@someone.to
   - name: Some One Else
     bio: "Another affiliation"
-date: 2020-06-24T09:00:00Z
+date: 2020-06-30
+time:
+  - start: 2020-07-15T15:00:00Z
+    end: 2020-07-15T15:30:00Z
 category: software_demo
 ---
 

--- a/_events/software_demos/event-002.md
+++ b/_events/software_demos/event-002.md
@@ -6,7 +6,10 @@ authors:
     email: someguy@someone.to
   - name: Co Author
     bio: "Another affiliation"
-date: 2020-07-03T18:00:00Z
+date: 2020-06-30T18:00:00Z
+time:
+  - start: 2020-07-24T18:00:00Z
+    end: 2020-07-24T18:15:00Z
 category: software_demo
 ---
 

--- a/_events/software_demos/event-002.md
+++ b/_events/software_demos/event-002.md
@@ -6,7 +6,7 @@ authors:
     email: someguy@someone.to
   - name: Co Author
     bio: "Another affiliation"
-date: 2020-06-30T18:00:00Z
+date: 2020-06-30
 time:
   - start: 2020-07-24T18:00:00Z
     end: 2020-07-24T18:15:00Z

--- a/_events/talks/event-003.md
+++ b/_events/talks/event-003.md
@@ -9,6 +9,9 @@ authors:
   - name: Some Guy
     bio: "Another affiliation"
 date: 2020-06-29T18:00:00Z
+time:
+  - start: 2020-07-29T18:00:00Z
+    end: 2020-07-29T18:30:00Z
 category: talk
 ---
 

--- a/_events/talks/event-003.md
+++ b/_events/talks/event-003.md
@@ -8,7 +8,7 @@ authors:
     bio: "Another affiliation"
   - name: Some Guy
     bio: "Another affiliation"
-date: 2020-06-29T18:00:00Z
+date: 2020-06-29
 time:
   - start: 2020-07-29T18:00:00Z
     end: 2020-07-29T18:30:00Z

--- a/_events/workshops/event-004.md
+++ b/_events/workshops/event-004.md
@@ -6,6 +6,7 @@ authors:
     email: somewhere@someone.to
   - name: Some One Else
     bio: "Another affiliation"
+    orcid: 0000-0001-6171-7716
   - name: Some Guy
     bio: "Another affiliation"
 date: 2020-07-11T18:00:00Z

--- a/_events/workshops/event-004.md
+++ b/_events/workshops/event-004.md
@@ -9,7 +9,12 @@ authors:
     orcid: 0000-0001-6171-7716
   - name: Some Guy
     bio: "Another affiliation"
-date: 2020-07-11T18:00:00Z
+date: 2020-06-30
+time:
+  - start: 2020-07-11T18:00:00Z
+    end: 2020-07-11T21:00:00Z
+  - start: 2020-07-12T18:00:00Z
+    end: 2020-07-12T21:00:00Z
 category: workshop
 ---
 

--- a/_includes/event-card.html
+++ b/_includes/event-card.html
@@ -1,0 +1,10 @@
+{% unless post.hidden %}
+<div class="card col-12 post-card">
+  <b class="card-title"><a href="{{ post.url | relative_url }}" rel="permalink" target="_blank">{{ post.title }}</a></b>
+  <div class="card-content" onclick="window.open('{{ post.url | relative_url }}')">
+    {% include event-summary.html event=post %}
+    <br>
+    {{ post.excerpt | markdownify | strip_html | truncate: 300 }}
+  </div>
+</div>
+{% endunless %}

--- a/_includes/event-summary-long.html
+++ b/_includes/event-summary-long.html
@@ -27,11 +27,12 @@
     {% assign email_link = '' %}
   {% endif %}
   {% if author.orcid %}
-    {% capture orcid %} <a href="https://orcid.org/{{ author.orcid }}"><span><i class="elastic-fai fab fa-orcid"></i></span></a>{% endcapture %}
+    {% capture author_name %}
+    <a itemprop="sameAs" content="https://orcid.org/{{ author.orcid }}" href="https://orcid.org/{{ author.orcid }}" target="orcid.widget" rel="me noopener noreferrer" style="vertical-align:top;"><img src="{{ '/assets/images/orcid.svg' | relative_url }}" style="width:1em;margin-right:.5em;" alt="ORCID iD icon">{{ author.name }}</a>{% endcapture %}
   {% else %}
-    {% assign orcid = '' %}
+    {% assign author_name = author.name %}
   {% endif %}
-  {{ author.name }}{{ affiliation }}{{ email_link}}{{ orcid }}{% unless forloop.last %}, {% endunless %}
+  {{ author_name }}{{ affiliation }}{{ email_link}}{% unless forloop.last %}, {% endunless %}
 
 {% endfor %}
 <div id="affiliations" class="footnotes" role="doc-endnotes">

--- a/_includes/event-summary-long.html
+++ b/_includes/event-summary-long.html
@@ -1,6 +1,6 @@
 {% assign event = include.event %}
 
-{% if event.authors %}
+<p>
 {% include group-by-array collection=event.authors field="bio" %}
 {% for author in event.authors %}
   {% assign author = site.data.authors[author] | default: author %}
@@ -46,4 +46,4 @@
 
 </p>
 
-{% endif %}
+<p class="page__date"><strong><i class="far fa-clock" aria-hidden="true"></i></strong> <time datetime="{{ event.date | date_to_xmlschema }}">{{ event.date | date: "%B %-d, %Y, %H:%M %Z" }}</time></p>

--- a/_includes/event-summary-long.html
+++ b/_includes/event-summary-long.html
@@ -1,0 +1,49 @@
+{% assign event = include.event %}
+
+{% if event.authors %}
+{% include group-by-array collection=event.authors field="bio" %}
+{% for author in event.authors %}
+  {% assign author = site.data.authors[author] | default: author %}
+  {% assign email = author.email %}
+  {% unless email %}
+    {% for link in author.links %}
+        {% if link.label == "Email" %}
+            {% assign email = link.url %}
+        {% endif %}
+    {% endfor %}
+  {% endunless %}
+  {% assign affil_num = '' %}
+  {% for affiliation in group_names %}
+    {% if affiliation == author.bio %}
+      {% assign affil_num = forloop.index %}
+      {% break %}
+    {% endif %}
+  {% endfor %}
+  {% capture affiliation %}<sup id="fnref:{{ affil_num }}" role="doc-noteref"><a href="#fn:{{ affil_num }}" class="footnote" title="{{ author.bio }}">{{ affil_num }}</a></sup>{% endcapture %}
+  {% if email %}
+    {% assign email = email | remove: "mailto:" %}
+    {% capture email_link %} <a href="mailto:{{ email }}" title='{{ email }}'><span><i class="elastic-fai fas fa-envelope"></i></span></a>{% endcapture %}
+  {% else %}
+    {% assign email_link = '' %}
+  {% endif %}
+  {% if author.orcid %}
+    {% capture orcid %} <a href="https://orcid.org/{{ author.orcid }}"><span><i class="elastic-fai fab fa-orcid"></i></span></a>{% endcapture %}
+  {% else %}
+    {% assign orcid = '' %}
+  {% endif %}
+  {{ author.name }}{{ affiliation }}{{ email_link}}{{ orcid }}{% unless forloop.last %}, {% endunless %}
+
+{% endfor %}
+<div id="affiliations" class="footnotes" role="doc-endnotes">
+  <ol>
+    {% for affiliation in group_names %}
+    <li id="fn:{{ forloop.index }}" role="doc-endnote">
+      {{ affiliation }}. <a href="#fnref:{{ forloop.index }}" class="reversefootnote" role="doc-backlink">&#8617;</a>
+    </li>
+    {% endfor %}
+  </ol>
+</div>
+
+</p>
+
+{% endif %}

--- a/_includes/event-summary-long.html
+++ b/_includes/event-summary-long.html
@@ -46,4 +46,10 @@
 
 </p>
 
-<p class="page__date"><strong><i class="far fa-clock" aria-hidden="true"></i></strong> <time datetime="{{ event.date | date_to_xmlschema }}">{{ event.date | date: "%B %-d, %Y, %H:%M %Z" }}</time></p>
+<ul class="page__date">
+  {% for time in event.time %}
+  <li>
+    {% include event-time.html %}
+  </li>
+  {% endfor %}
+</ul>

--- a/_includes/event-summary.html
+++ b/_includes/event-summary.html
@@ -5,5 +5,11 @@
   {% assign author = site.data.authors[author] | default: author %}
   <b>{{ author.name }}</b>{% unless forloop.last %}, {% endunless %}
 {% endfor %}
-<div class="page__date"><strong><i class="far fa-clock" aria-hidden="true"></i></strong> <time datetime="{{ event.date | date_to_xmlschema }}">{{ event.date | date: "%B %-d, %Y, %H:%M %Z" }}</time></div>
+<ul class="page__date">
+  {% for time in event.time %}
+  <li>
+    {% include event-time.html %}
+  </li>
+  {% endfor %}
+</ul>
 {% endif %}

--- a/_includes/event-summary.html
+++ b/_includes/event-summary.html
@@ -1,0 +1,9 @@
+{% assign event = include.event %}
+
+{% if event.authors %}
+{% for author in event.authors %}
+  {% assign author = site.data.authors[author] | default: author %}
+  <b>{{ author.name }}</b>{% unless forloop.last %}, {% endunless %}
+{% endfor %}
+<div class="page__date"><strong><i class="far fa-clock" aria-hidden="true"></i></strong> <time datetime="{{ event.date | date_to_xmlschema }}">{{ event.date | date: "%B %-d, %Y, %H:%M %Z" }}</time></div>
+{% endif %}

--- a/_includes/event-time.html
+++ b/_includes/event-time.html
@@ -1,0 +1,13 @@
+<strong><i class="far fa-clock" aria-hidden="true"></i></strong> <time datetime="{{ time.start | date_to_xmlschema }}">{{ time.start | date: "%B %-d, %Y, %H:%M %Z" }}</time>
+{% if time.end %}
+&ndash;
+<time datetime="{{ time.end | date_to_xmlschema }}">
+  {%- capture start_day -%}{{ time.start | date: "%Y-%m-%d" }}{%- endcapture -%}
+  {%- capture end_day -%}{{ time.end | date: "%Y-%m-%d" }}{%- endcapture -%}
+  {%- if start_day == end_day -%}
+  {{ time.end | date: "%H:%M %Z" }}
+  {%- else -%}
+  {{ time.end | date: "%B %-d, %Y, %H:%M %Z" }}
+  {%- endif -%}
+</time>
+{% endif %}

--- a/_includes/event.js
+++ b/_includes/event.js
@@ -1,8 +1,10 @@
+{%- for time in post.time -%}
 {
-  title  : '{{ post.title }}',
+  title  : '{{ post.title }}{% unless forloop.first %} (continued){% endunless %}',
   url    : "{{ post.url | relative_url }}",
   allDay : {% if post.all_day %}true{% else %}false{% endif %},
   category : "{{ post.category }}",
-  {% unless post.end_date %}// {% endunless %}end    : '{{ event.end_date | date_to_xmlschema }},'
-  start  : '{{ post.date | date_to_xmlschema }}'
-}
+  {% unless time.end %}// {% endunless %}end    : '{{ time.end | date_to_xmlschema }}',
+  start  : '{{ time.start | date_to_xmlschema }}'
+}{% unless forloop.last %},{% endunless %}
+{%- endfor -%}

--- a/_includes/events-subcollection.html
+++ b/_includes/events-subcollection.html
@@ -1,0 +1,21 @@
+{% assign entries = include.collection %}
+
+{% if include.sort_by == 'title' %}
+  {% if include.sort_order == 'reverse' %}
+    {% assign entries = entries | sort: 'title' | reverse %}
+  {% else %}
+    {% assign entries = entries | sort: 'title' %}
+  {% endif %}
+{% elsif include.sort_by == 'date' %}
+  {% if include.sort_order == 'reverse' %}
+    {% assign entries = entries | sort: 'date' | reverse %}
+  {% else %}
+    {% assign entries = entries | sort: 'date' %}
+  {% endif %}
+{% endif %}
+
+{%- for post in entries -%}
+  {%- unless post.hidden -%}
+    {% include event-card.html %}
+  {%- endunless -%}
+{%- endfor -%}

--- a/_layouts/all-events.html
+++ b/_layouts/all-events.html
@@ -1,0 +1,30 @@
+---
+layout: archive
+---
+
+{% assign collection = site[page.collection] %}
+{% include group-by-array collection=collection field="category" %}
+
+<ul class="taxonomy__index">
+  {% for category in group_names %}
+  {% assign category_name = site.data.committee.programme_teams[category].name | default: category %}
+    <li>
+      <a href="#{{ category | slugify | downcase }}">
+        <strong>{{ category_name }}</strong> <span class="taxonomy__count">{{ group_items[forloop.index0] | size }}</span>
+      </a>
+    </li>
+  {% endfor %}
+</ul>
+
+
+{{ content }}
+
+
+{% for category in group_names %}
+  {% assign category_name = site.data.committee.programme_teams[category].name | default: category %}
+  {% assign posts = group_items[forloop.index0] %}
+  <section id="{{ category | slugify | downcase }}" class="taxonomy__section">
+    <h2>{{ category_name }}</h2>
+      {% include events-subcollection.html collection=posts sort_by=page.sort_by sort_order=page.sort_order type=page.entries_layout %}
+  </section>
+{% endfor %}

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -1,0 +1,9 @@
+---
+layout: single
+---
+
+{% include event-summary-long.html event=page %}
+
+{{ content }}
+
+{% include team-button.html team=page.category %}

--- a/_pages/programme/index.md
+++ b/_pages/programme/index.md
@@ -1,6 +1,6 @@
 ---
 title: Programme
-layout: collection-categories
+layout: all-events
 collection: events
 permalink: /programme/
 sidebar:

--- a/assets/images/orcid.svg
+++ b/assets/images/orcid.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 256 256" style="enable-background:new 0 0 256 256;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#A6CE39;}
+	.st1{fill:#FFFFFF;}
+</style>
+<path class="st0" d="M256,128c0,70.7-57.3,128-128,128C57.3,256,0,198.7,0,128C0,57.3,57.3,0,128,0C198.7,0,256,57.3,256,128z"/>
+<g>
+	<path class="st1" d="M86.3,186.2H70.9V79.1h15.4v48.4V186.2z"/>
+	<path class="st1" d="M108.9,79.1h41.6c39.6,0,57,28.3,57,53.6c0,27.5-21.5,53.6-56.8,53.6h-41.8V79.1z M124.3,172.4h24.5
+		c34.9,0,42.9-26.5,42.9-39.7c0-21.5-13.7-39.7-43.7-39.7h-23.7V172.4z"/>
+	<path class="st1" d="M88.7,56.8c0,5.5-4.5,10.1-10.1,10.1c-5.6,0-10.1-4.6-10.1-10.1c0-5.6,4.5-10.1,10.1-10.1
+		C84.2,46.7,88.7,51.3,88.7,56.8z"/>
+</g>
+</svg>


### PR DESCRIPTION
In this PR, we add information about authors and time of the event to the corresponding pages, as well as to the summary on the `/programme/` page, see https://20-276193679-gh.circle-artifacts.com/0/SORSE/programme/software_demos/event-001/index.html.

We also use cards to display the events on the `/programme/` page, see https://20-276193679-gh.circle-artifacts.com/0/SORSE/programme/index.html

Any comments @vsoch?